### PR TITLE
Subir el patch en cada merge a main

### DIFF
--- a/.github/workflows/version-patch.yml
+++ b/.github/workflows/version-patch.yml
@@ -1,0 +1,39 @@
+# Sube el patch en cada merge a main. El patch cuenta despliegues, no cambios de
+# cara al cliente: por eso NO toca CHANGELOG.md. La version que lee el cliente la
+# cierra una persona con /release.
+name: Version patch
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  patch:
+    # El commit del bump no puede volver a dispararse a si mismo
+    if: "!contains(github.event.head_commit.message, '[skip version]')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Subir patch y taggear
+        run: |
+          set -e
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          V=$(jq -r .version package.json)
+          IFS=. read -r MA MI PA <<< "$V"
+          NUEVA="$MA.$MI.$((PA+1))"
+
+          tmp=$(mktemp); jq --arg v "$NUEVA" '.version=$v' package.json > "$tmp" && mv "$tmp" package.json
+          git add package.json
+          git commit -m "$NUEVA [skip version]"
+          git tag -a "v$NUEVA" -m "$NUEVA"
+          git push origin HEAD:main --follow-tags
+          echo "Desplegada $NUEVA" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
El numero de version deja de moverse a mano.

**Que hace**: en cada merge a `main`, sube el patch del `package.json` (`0.1.0` → `0.1.1`) y crea el tag `v0.1.1`. Asi cada despliegue queda identificado sin que nadie se acuerde de nada.

**Que NO hace**: tocar el `CHANGELOG.md`. El patch cuenta despliegues, no cosas que contarle a un cliente. La version que el cliente lee (`0.1.x` → `0.2.0`) se cierra aparte, y ese es el momento en que `[Unreleased]` pasa a ser una version publicada.

**Detalle**: el commit del bump lleva `[skip version]` y el workflow lo filtra, para que no se dispare a si mismo en bucle.

De paso este PR crea la branch `develop`, que el repo no tenia.

Al mergear esto, la primera ejecucion va a dejar el repo en `0.1.1`.