### PR TITLE
Arrancar el CHANGELOG del proyecto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog — RP9
+
+Todo cambio que llega a produccion se anota aqui, lo mas reciente arriba. Cada entrada lleva una
+linea de negocio —lo que gana quien usa el producto— y una linea tecnica en comentario HTML.
+
+Formato, secciones y como se cierra una version: skill `changelog-proyecto`.
+
+## [Unreleased]
+
+## Antes de este changelog
+
+El trabajo anterior al 2026-08-01 no esta desglosado aqui: es historial y no se reconstruye. Ver
+`git log` para el detalle de commits.
+
+El numero de version que se mueve solo en cada despliegue lo pone
+`.github/workflows/version-patch.yml` y cuenta subidas, no cambios de cara al cliente. Las
+versiones que lee el cliente empiezan a partir de la primera entrada de arriba.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,3 +87,12 @@ Para bugs críticos que requieren deploy inmediato:
 ## Notes
 
 This CLAUDE.md will be updated as the project grows and the codebase structure becomes more defined.
+## Historial de cambios
+
+`CHANGELOG.md` en la raiz. **Antes de tocar codigo**: revisar la ultima version y `[Unreleased]`
+para saber que se movio. **Al terminar**: agregar la entrada bajo `[Unreleased]` en el mismo
+commit — linea de negocio + linea `<!-- tec: -->`.
+
+Si `[Unreleased]` da conflicto al mergear: se conservan **los dos** bullets, nunca se elige lado.
+
+Estandar completo: skill `changelog-proyecto`.


### PR DESCRIPTION
El repo ya versiona solo en cada despliegue, pero ese numero cuenta subidas. Esto arranca el registro que lee quien paga.

No reconstruye historia: abre en `[Unreleased]` y lo anterior queda en `git log`. El bloque en `CLAUDE.md` es lo que hace que quien entre al repo sepa que existe.